### PR TITLE
Register functions to an existing SparkSession

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,8 @@
 
 name := "itachi"
 
+version := "0.2.0"
+
 scalaVersion := "2.12.10"
 
 val sparkVersion = "3.1.0"

--- a/src/main/scala/yaooqinn/itachi/package.scala
+++ b/src/main/scala/yaooqinn/itachi/package.scala
@@ -1,0 +1,24 @@
+package yaooqinn
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.postgresql._
+import org.apache.spark.sql.extra.FunctionAliases
+
+package object itachi {
+
+  def registerPostgresFunctions: Unit = {
+    val spark = SparkSession.getActiveSession.get
+    spark.sessionState.functionRegistry.registerFunction(Age.fd._1, Age.fd._2, Age.fd._3)
+    spark.sessionState.functionRegistry.registerFunction(FunctionAliases.array_cat._1, FunctionAliases.array_cat._2, FunctionAliases.array_cat._3)
+    spark.sessionState.functionRegistry.registerFunction(ArrayAppend.fd._1, ArrayAppend.fd._2, ArrayAppend.fd._3)
+    spark.sessionState.functionRegistry.registerFunction(ArrayLength.fd._1, ArrayLength.fd._2, ArrayLength.fd._3)
+    spark.sessionState.functionRegistry.registerFunction(IntervalJustifyLike.justifyDays._1, IntervalJustifyLike.justifyDays._2, IntervalJustifyLike.justifyDays._3)
+    spark.sessionState.functionRegistry.registerFunction(IntervalJustifyLike.justifyHours._1, IntervalJustifyLike.justifyHours._2, IntervalJustifyLike.justifyHours._3)
+    spark.sessionState.functionRegistry.registerFunction(IntervalJustifyLike.justifyInterval._1, IntervalJustifyLike.justifyInterval._2, IntervalJustifyLike.justifyInterval._3)
+    spark.sessionState.functionRegistry.registerFunction(Scale.fd._1, Scale.fd._2, Scale.fd._3)
+    spark.sessionState.functionRegistry.registerFunction(SplitPart.fd._1, SplitPart.fd._2, SplitPart.fd._3)
+    spark.sessionState.functionRegistry.registerFunction(StringToArray.fd._1, StringToArray.fd._2, StringToArray.fd._3)
+    spark.sessionState.functionRegistry.registerFunction(UnNest.fd._1, UnNest.fd._2, UnNest.fd._3)
+  }
+
+}

--- a/src/test/scala/yaooqinn/ItachiTest.scala
+++ b/src/test/scala/yaooqinn/ItachiTest.scala
@@ -1,0 +1,21 @@
+package yaooqinn
+
+import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.extra.SparkSessionHelper
+import org.apache.spark.unsafe.types.CalendarInterval
+
+class ItachiTest extends SparkSessionHelper {
+
+  def checkAnswer(df: DataFrame, expect: Seq[Row]): Unit = {
+    assert(df.collect() === expect)
+  }
+
+  test("age") {
+    yaooqinn.itachi.registerPostgresFunctions
+    checkAnswer(
+      spark.sql("select age(timestamp '2001-04-10',  timestamp '1957-06-13')"),
+      Seq(Row(new CalendarInterval(525, 28, 0)))
+    )
+  }
+
+}


### PR DESCRIPTION
I thought about it more and actually don't think `spark.sessionState.functionRegistry.registerFunction` is so bad.  `spark.registerFunction[Age]("age")` would be a bit cleaner, but it's not like end users will have to invoke this code anyways.

Users can create a cluster, run `yaooqinn.itachi.registerPostgresFunctions` and then have access to all the Postgres functions.  They don't need to worry about setting any configuration options (or init scripts if they're in Databricks).

This is a small change, but hugely important for end users.  The existing setup will scare some less technical users away.  This interface will encourage the users to start using this lib ;)

Let me know if this syntax looks ok to you.  If it looks good, we can add a function that registers the Teradata functions in a similar manner.